### PR TITLE
fix(combobox): use static positioning for flyout

### DIFF
--- a/src/components/og-card/og-card.tsx
+++ b/src/components/og-card/og-card.tsx
@@ -17,6 +17,9 @@ export class OgCard {
         }
 
         let slot = el.firstChild as HTMLSlotElement;
+        if (!slot.assignedNodes) {
+            return;
+        }
         el.style.display = slot.assignedNodes().length > 0 ? 'block' : 'none';
 
         slot.addEventListener('slotchange', () => {

--- a/src/components/og-combobox/og-combobox.scss
+++ b/src/components/og-combobox/og-combobox.scss
@@ -165,7 +165,7 @@
     padding: 0;
     list-style-type: none;
     display: none;
-    position: absolute;
+    position: fixed;
     width: 100%;
     box-shadow: var(--og-combobox__flyout-BoxShadow);
     background:  var(--og-combobox__flyout-Background);

--- a/src/index.html
+++ b/src/index.html
@@ -65,7 +65,7 @@
     <div style="width: 100%; max-width: 800px;">
         <h1>ORGENIC UI</h1>
         <!--
-        -- Theme Switch
+        Theme Switch
         -->
         <og-card name="Switch Theme">
             <div slot="content" slot="content">
@@ -87,7 +87,7 @@
         </script>
 
         <!--
-        -- Expander
+        Expander
         -->
         <og-card name="Expander">
             <div slot="content" slot="content">
@@ -110,7 +110,7 @@
         </og-card>
 
         <!--
-        -- og-datatable
+        og-datatable
         -->
         <og-card name="Datatable">
             <div slot="content" class="example example--column">
@@ -255,7 +255,7 @@
         </script>
 
         <!--
-        -- og-form-item
+        og-form-item
         -->
         <og-card name="Form Item">
             <div slot="content" class="example example--column">
@@ -281,8 +281,8 @@
         </script>
 
         <!--
--- og-text-input
--->
+        og-text-input
+        -->
         <og-card name="Text Input">
             <div slot="content" class="example example--column">
                 <div>
@@ -312,7 +312,7 @@
         </script>
 
         <!--
-        -- og-textarea
+        og-textarea
         -->
         <og-card name="Textarea">
             <div slot="content" class="example example--column">
@@ -334,7 +334,7 @@
         </script>
 
         <!--
-        -- og-number-input
+        og-number-input
         -->
         <og-card name="Number Input">
             <div slot="content" class="example example--column">
@@ -366,7 +366,7 @@
         </script>
 
         <!--
-        -- og-password-input
+        og-password-input
         -->
         <og-card name="Password Input">
             <div slot="content" class="example example--column">
@@ -399,7 +399,7 @@
 
 
         <!--
-        -- og-radio-button-group
+        og-radio-button-group
         -->
         <og-card name="Radio Button Group">
             <form slot="content">
@@ -443,7 +443,7 @@
         </script>
 
         <!--
-        -- og-tab-container
+        og-tab-container
         -->
         <og-card name="Tabs">
             <div slot="content" class="example">
@@ -470,7 +470,7 @@
         </og-card>
 
         <!--
-        -- og-checkbox
+        og-checkbox
         -->
         <og-card name="Checkbox">
             <div slot="content" class="example">
@@ -489,7 +489,7 @@
         </script>
 
         <!--
-        -- og-toggle-switch
+        og-toggle-switch
         -->
         <og-card name="Toggle Switch">
             <div slot="content" class="example">
@@ -507,7 +507,7 @@
         </script>
 
         <!--
-        -- og-button
+        og-button
         -->
         <og-card name="Buttons">
             <div slot="content" class="example">
@@ -527,7 +527,7 @@
         </script>
 
         <!--
-        -- og-list
+        og-list
         -->
         <og-card name="List">
             <div slot="content">
@@ -564,7 +564,7 @@
         </script>
 
         <!--
-        -- og-combobox
+        og-combobox
         -->
         <og-card name="Combobox">
             <div slot="content" class="example example--column">

--- a/src/utils/scroll-handler.ts
+++ b/src/utils/scroll-handler.ts
@@ -1,0 +1,15 @@
+export class ScrollHandler {
+    public static cancelScrollingKeyFilter = (ev: KeyboardEvent) => {
+        /* 33: pgup; 34: pgdwn; 35: end; 36: pos1; 37 - 40: arrows */
+        if (ev.keyCode >= 33 && ev.keyCode <= 40) {
+            ScrollHandler.cancelScrolling(ev);
+        }
+    }
+
+    public static cancelScrolling = (ev: Event) => {
+        if (ev.preventDefault) {
+            ev.preventDefault();
+        }
+        ev.returnValue = false;
+    };
+}


### PR DESCRIPTION
# Pull Request

## Type of change

- [x] Bug fix (a non-breaking change which fixes an issue - please add the issue reference in the description section)

## Description

Scenario: Comboboxes in containers with overflow hidden. If the flyout goes out of the container, it gets cut off. Flyout is now positioned fixed and does not get cut off.

## Checklist

- [x] Local build is still running with my changes
- [ ] I added tests 
- [x] New and existing unit test pass locally with my changes
- [x] My changes do not contain any dead or commented out code
- [ ] I added documentation for public functionality
- [ ] I added comments, at least in hard-to-understand areas

