### PR TITLE
Fix og card headerless

### DIFF
--- a/src/components/og-card/og-card.tsx
+++ b/src/components/og-card/og-card.tsx
@@ -33,9 +33,12 @@ export class OgCard {
     render() {
         return (
             <div class="og-card">
-                <div class="og-card__header">
-                    <span class="og-card__title">{ this.name }</span>
-                </div>
+                { this.name
+                    ?   <div class="og-card__header">
+                            <span class="og-card__title">{ this.name }</span>
+                        </div>
+                    :   ""
+                }
                 <div class="og-card__content">
                     <slot name="content"></slot>
                 </div>

--- a/src/components/og-card/og-card.tsx
+++ b/src/components/og-card/og-card.tsx
@@ -13,7 +13,7 @@ import { Component, Prop } from '@stencil/core';
 })
 export class OgCard {
     /**
-     * The name for this card
+     * The title for this card (optional)
      */
     @Prop() name: string;
 


### PR DESCRIPTION
# Pull Request

## Type of change

- [x] Bug fix (a non-breaking change which fixes an issue - please add the issue reference in the description section)

## Description

og-card can be used without a header. The attribute "name" is optional.

Fixes issue #40 

## Checklist

- [x] My changes do not contain any dead or commented out code
- [x] I added documentation for public functionality
