### PR TITLE
fix: og-form-item label postion when og-number-input is cleared

### DIFF
--- a/src/components/og-form-item/og-form-item.tsx
+++ b/src/components/og-form-item/og-form-item.tsx
@@ -55,7 +55,11 @@ export class OgFormItem {
         });
 
         this.editor.addEventListener('valueChanged', (event: CustomEvent) => {
-            this.editorIsEmpty = event.detail.length === 0;
+            this.editorIsEmpty = true;
+            
+            if (event.detail) {
+                this.editorIsEmpty = event.detail.length === 0;
+            }            
         });
 
         this.editorIsEmpty = !this.editor['value'] || this.editor['value'].length === 0;

--- a/src/components/og-form-item/og-form-item.tsx
+++ b/src/components/og-form-item/og-form-item.tsx
@@ -55,11 +55,7 @@ export class OgFormItem {
         });
 
         this.editor.addEventListener('valueChanged', (event: CustomEvent) => {
-            this.editorIsEmpty = true;
-            
-            if (event.detail) {
-                this.editorIsEmpty = event.detail.length === 0;
-            }            
+            this.editorIsEmpty = !event.detail || event.detail.length === 0;
         });
 
         this.editorIsEmpty = !this.editor['value'] || this.editor['value'].length === 0;

--- a/src/components/og-input/og-number-input/og-number-input.tsx
+++ b/src/components/og-input/og-number-input/og-number-input.tsx
@@ -54,9 +54,13 @@ export class OgNumberInput {
 
     handleChange(e) {
         const value = parseFloat(e.target.value);
+        
         if (!isNaN(value)) {
             this.value = value;
+        } else {
+            this.value = null;
         }
+        
         this.valueChanged.emit(this.value);
     }
 

--- a/src/index.html
+++ b/src/index.html
@@ -319,6 +319,9 @@
                     <og-form-item label="Default Text Input">
                         <og-text-input id="input#1"></og-text-input>
                     </og-form-item>
+                    <og-form-item label="Default Number Input">
+                        <og-number-input></og-number-input>
+                    </og-form-item>
                     <og-form-item label="Default Combobox" id="formItemCombobox">
                         <og-combobox value="3"></og-combobox>
                     </og-form-item>
@@ -395,10 +398,8 @@
         <og-card name="Number Input">
             <div slot="content" class="example example--column">
                 <div>
-                    <!-- <label for="numberInput#1">Default Number Input</label> -->
-                    <og-form-item label="Number">
-                        <og-number-input id="numberInput#1"></og-number-input>
-                    </og-form-item>
+                    <label for="numberInput#1">Default Number Input</label>
+                    <og-number-input id="numberInput#1"></og-number-input>
                 </div>
                 <div>
                     <label for="numberInput#2">Number Input with placeholder</label>

--- a/src/index.html
+++ b/src/index.html
@@ -395,8 +395,10 @@
         <og-card name="Number Input">
             <div slot="content" class="example example--column">
                 <div>
-                    <label for="numberInput#1">Default Number Input</label>
-                    <og-number-input id="numberInput#1"></og-number-input>
+                    <!-- <label for="numberInput#1">Default Number Input</label> -->
+                    <og-form-item label="Number">
+                        <og-number-input id="numberInput#1"></og-number-input>
+                    </og-form-item>
                 </div>
                 <div>
                     <label for="numberInput#2">Number Input with placeholder</label>


### PR DESCRIPTION
# Pull Request

## Type of change

Please delete any option that is not relevant.

- [x] Bug fix (a non-breaking change which fixes an issue - please add the issue reference in the description section)

## Description

When using og-form-item around og-number-input, the label position is now updated correctly, when the field is cleared.

## Checklist

- [x] My changes do not contain any dead or commented out code