### PR TITLE
Fix datatable select

### DIFF
--- a/src/components/og-datatable/og-datatable.scss
+++ b/src/components/og-datatable/og-datatable.scss
@@ -28,7 +28,11 @@
 
     --og-datatable__tabulator-row-Background: transparent;
     --og-datatable__tabulator-row-Background--even: var(--og-datatable__tabulator-row-Background);
-    --og-datatable__tabulator-row-Background--hover: transparent;
+    --og-datatable__tabulator-row-Background--hover: var( --OG-COLOR-PRIMARY--100--15, #{$og-color-primary--100--15});
+    --og-datatable__tabulator-row-Background--selected: var( --OG-COLOR-PRIMARY--100--30, #{$og-color-primary--100--30});
+    --og-datatable__tabulator-row-Background--selected-hover: var( --OG-COLOR-PRIMARY--100--30, #{$og-color-primary--100--30});
+    // --og-datatable__tabulator-row-Background--selected: var( --OG-COLOR-SHADE--100--10, #{$og-color-shade--100--10});
+    // --og-datatable__tabulator-row-Background--selected-hover: var( --OG-COLOR-PRIMARY--100--50, #{$og-color-primary--100--50});
     --og-datatable__tabulator-row-BorderWidth: 0 0 1px 0;
     --og-datatable__tabulator-row-BorderStyle: solid;
     --og-datatable__tabulator-row-BorderColor: var(--OG-COLOR-SHADE--100--20, #{$og-color-shade--100--20});
@@ -198,13 +202,22 @@
     background: var(--og-datatable__tabulator-row-Background);
     border-bottom: none;
     color: inherit;
+    transition: all .3s ease;
 
     &.tabulator-row-even {
         background-color: var(--og-datatable__tabulator-row-Background--even);
     }
 
-    &.tabulator-selectable:hover {
-        background: var(--og-datatable__tabulator-row-Background--hover);
+    &.tabulator-selectable {
+        &.tabulator-selected {
+            background: var(--og-datatable__tabulator-row-Background--selected);
+            &:hover {
+                background: var(--og-datatable__tabulator-row-Background--selected-hover);
+            }
+        }
+        &:hover {
+            background: var(--og-datatable__tabulator-row-Background--hover);
+        }
     }
 
     .tabulator-cell {

--- a/src/components/og-datatable/og-datatable.scss
+++ b/src/components/og-datatable/og-datatable.scss
@@ -31,8 +31,6 @@
     --og-datatable__tabulator-row-Background--hover: var( --OG-COLOR-PRIMARY--100--15, #{$og-color-primary--100--15});
     --og-datatable__tabulator-row-Background--selected: var( --OG-COLOR-PRIMARY--100--30, #{$og-color-primary--100--30});
     --og-datatable__tabulator-row-Background--selected-hover: var( --OG-COLOR-PRIMARY--100--30, #{$og-color-primary--100--30});
-    // --og-datatable__tabulator-row-Background--selected: var( --OG-COLOR-SHADE--100--10, #{$og-color-shade--100--10});
-    // --og-datatable__tabulator-row-Background--selected-hover: var( --OG-COLOR-PRIMARY--100--50, #{$og-color-primary--100--50});
     --og-datatable__tabulator-row-BorderWidth: 0 0 1px 0;
     --og-datatable__tabulator-row-BorderStyle: solid;
     --og-datatable__tabulator-row-BorderColor: var(--OG-COLOR-SHADE--100--20, #{$og-color-shade--100--20});
@@ -51,7 +49,6 @@
     --og-datatable__tabulator-page-Color--hover: var(--OG-COLOR-SHADE--100, #{$og-color-shade--100});
     --og-datatable__tabulator-page-Color--active: var(--OG-COLOR-SHADE--100, #{$og-color-shade--100});
     --og-datatable__tabulator-page-Color--disabled: var(--OG-COLOR-SHADE--100--30, #{$og-color-shade--100--30});
-
 }
 
 // @import '../../../node_modules/tabulator-tables/dist/css/tabulator.css';

--- a/src/index.html
+++ b/src/index.html
@@ -296,6 +296,7 @@
 
             const dtConfig = {
                 noDataMessage: 'No items available',
+                selectable: true,
                 // dataService: scrollData,
                 dataService: scrollLazyData,
                 // dataService: paginatedData,


### PR DESCRIPTION
Rows selected in the datatable would only display an even rows and hovering them, hides the selection color.

Signed-off-by: Tobias Dobbrunz <tobias.dobbrunz@maximago.de>

# Pull Request

## Type of change

Please delete any option that is not relevant.

- [x] Bug fix (a non-breaking change which fixes an issue - please add the issue reference in the description section)

## Description

Please include a summary of the change and which issue is fixed. 

Fixes weird hover effect on datatables 

## Checklist

- [x] Local build is still running with my changes
- [ ] I added tests 
- [x] New and existing unit test pass locally with my changes
- [x] My changes do not contain any dead or commented out code
- [ ] I added documentation for public functionality
- [ ] I added comments, at least in hard-to-understand areas

