### PR TITLE
added unnamed slot next to content slot to simplify usage

### DIFF
--- a/src/components/og-card/og-card.tsx
+++ b/src/components/og-card/og-card.tsx
@@ -37,6 +37,8 @@ export class OgCard {
                     <span class="og-card__title">{ this.name }</span>
                 </div>
                 <div class="og-card__content">
+                    {/* allow the user to use an unnamed slot instead of always having to assign as "content" */}
+                    <slot></slot>
                     <slot name="content"></slot>
                 </div>
                 <div class="og-card__footer" ref={ el => this.handleDivRef(el) }>

--- a/src/components/og-card/readme.md
+++ b/src/components/og-card/readme.md
@@ -18,6 +18,7 @@
 | `--og-card-BorderColor`           | Border color of the cards border        |
 | `--og-card-BorderRadius`          | Border radius of the cards border       |
 | `--og-card-BorderWidth`           | Border width of the cards border        |
+| `--og-card-BoxShadow`             | Box shadow of the card                  |
 | `--og-card-Margin`                | Margin around the card                  |
 | `--og-card__content-Padding`      | Padding of the cards content            |
 | `--og-card__footer-Padding`       | Padding of the cards footer             |

--- a/src/components/og-dialog/og-confirm-dialog/og-confirm-dialog.tsx
+++ b/src/components/og-dialog/og-confirm-dialog/og-confirm-dialog.tsx
@@ -55,9 +55,7 @@ export class OgConfirmDialog {
     render() {
         return (
             <og-dialog class="og-dialog--info" name={ this.name } svg-icon={ this.svgIcon } visible={ this.visible }>
-                <div slot="content">
-                    <slot></slot>
-                </div>
+                <slot></slot>
                 <div slot="footer">
                     <og-button label={ this.cancelLabel } onClicked={ _e => this.handleCancel() }></og-button>{' '}
                     <og-button data-context="workflow" label={ this.confirmLabel } onClicked={ _e => this.handleConfirm() }></og-button>

--- a/src/components/og-dialog/og-dialog.tsx
+++ b/src/components/og-dialog/og-dialog.tsx
@@ -65,7 +65,8 @@ export class OgDialog {
                         <span class="og-dialog__title">{ this.name }</span>
                     </div>
                     <div class="og-dialog__content">
-
+                        {/* allow the user to use an unnamed slot instead of always having to assign as "content" */}
+                        <slot></slot>
                         <slot name="content"></slot>
                     </div>
                     <div class="og-dialog__footer">

--- a/src/components/og-dialog/og-message-dialog/og-message-dialog.tsx
+++ b/src/components/og-dialog/og-message-dialog/og-message-dialog.tsx
@@ -53,9 +53,7 @@ export class OgMessageDialog {
     render() {
         return (
             <og-dialog class={ 'og-dialog--' + this.type } name={ this.name } svg-icon={ this.getIcon() } visible={ this.visible }>
-                <div slot="content">
-                    <slot></slot>
-                </div>
+                <slot></slot>
                 <div slot="footer">
                     <og-button label={ this.approveLabel } onClicked={ _e => this.handleConfirm() }></og-button>
                 </div>

--- a/src/components/og-dialog/readme.md
+++ b/src/components/og-dialog/readme.md
@@ -38,6 +38,7 @@
 | `--og-dialog__header-Display`       | Box Model of the Dialog Header                               |
 | `--og-dialog__header-FontSize`      | Font Size of the Dialog Header                               |
 | `--og-dialog__header-FontWeight`    | Font Weight of the Dialog Header                             |
+| `--og-dialog__header-Margin`        | Margin of the Dialog Header                                  |
 | `--og-dialog__header-Padding`       | Padding of the Dialog Header                                 |
 | `--og-dialog__header-TextOverflow`  | Text Overflow Behaviour of the Dialog Header                 |
 | `--og-dialog__header-TextTransform` | Text Transformation of the Dialog Header                     |

--- a/src/index.html
+++ b/src/index.html
@@ -74,7 +74,7 @@
         Theme Switch
         -->
         <og-card name="Switch Theme">
-            <div slot="content" slot="content">
+            <div>
                 It's possible to change ORGENIC UI themes at application runtime without reloading.
                 <br /><br />
                 <b>Choose your favourite theme!</b>
@@ -97,9 +97,9 @@
         og-dialog
         -->
         <og-card name="Dialog">
-            <div slot="content" slot="content">
+            <div>
                 <og-dialog name="Custom Dialog" id="customDialog">
-                    <div slot="content">Custom Dialog Content</div>
+                    <div>Custom Dialog Content</div>
                     <div slot="footer">
                         <og-button label="Close Dialog" id="closeCustomDialog"></og-button>
                     </div>
@@ -146,7 +146,7 @@
         og-expander
         -->
         <og-card name="Expander">
-            <div slot="content" slot="content">
+            <div>
                 <og-expander name="ORGENIC Expander 1.1" group="a">
                     Some very interesting information about ORGENIC UI is [...]. And that's why we [...] all the things!
                 </og-expander>
@@ -169,7 +169,7 @@
         og-datatable
         -->
         <og-card name="Datatable">
-            <div slot="content" class="example example--column">
+            <div class="example example--column">
                 <p>
                     ORGENIC UI Datagrid supports scrolling and paging presentation as well as a lazy loading data
                     provider.
@@ -314,7 +314,7 @@
         og-form-item
         -->
         <og-card name="Form Item">
-            <div slot="content" class="example example--column">
+            <div class="example example--column">
                 <div>
                     <og-form-item label="Default Text Input">
                         <og-text-input id="input#1"></og-text-input>
@@ -340,7 +340,7 @@
         og-text-input
         -->
         <og-card name="Text Input">
-            <div slot="content" class="example example--column">
+            <div class="example example--column">
                 <div>
                     <label for="input#1">Default Text Input</label>
                     <og-text-input id="input#1"></og-text-input>
@@ -371,7 +371,7 @@
         og-textarea
         -->
         <og-card name="Textarea">
-            <div slot="content" class="example example--column">
+            <div class="example example--column">
                 <div>
                     <label for="textarea1">Default Textarea</label>
                     <og-textarea id="textarea1"></og-textarea>
@@ -393,7 +393,7 @@
         og-number-input
         -->
         <og-card name="Number Input">
-            <div slot="content" class="example example--column">
+            <div class="example example--column">
                 <div>
                     <label for="numberInput#1">Default Number Input</label>
                     <og-number-input id="numberInput#1"></og-number-input>
@@ -425,7 +425,7 @@
         og-password-input
         -->
         <og-card name="Password Input">
-            <div slot="content" class="example example--column">
+            <div class="example example--column">
                 <div>
                     <label for="password#1">Default Password Input</label>
                     <og-password-input id="password#1"></og-password-input>
@@ -458,7 +458,7 @@
         og-radio-button-group
         -->
         <og-card name="Radio Button Group">
-            <form slot="content">
+            <form>
                 <div class="example">
                     <og-radio-button-group name="bg1" selected-value="r">
                         <og-radio-button label="Angular" value="ng"></og-radio-button>
@@ -502,7 +502,7 @@
         og-tab-container
         -->
         <og-card name="Tabs">
-            <div slot="content" class="example">
+            <div class="example">
                 <og-tab-container>
                     <og-tab label="Angular Example" selected>Show here how to use component in Angular</og-tab>
                     <og-tab label="React Example">Show here how to use component in React</og-tab>
@@ -529,7 +529,7 @@
         og-checkbox
         -->
         <og-card name="Checkbox">
-            <div slot="content" class="example">
+            <div class="example">
                 <og-checkbox label="Default Checkbox"></og-checkbox>
                 <og-checkbox label="Disabled Checkbox" checked disabled></og-checkbox>
                 <og-checkbox label="Disabled Checkbox" disabled></og-checkbox>
@@ -548,7 +548,7 @@
         og-toggle-switch
         -->
         <og-card name="Toggle Switch">
-            <div slot="content" class="example">
+            <div class="example">
                 <og-toggle-switch value="false"></og-toggle-switch>
                 <og-toggle-switch value="true" disabled></og-toggle-switch>
             </div>
@@ -566,7 +566,7 @@
         og-button
         -->
         <og-card name="Buttons">
-            <div slot="content" class="example">
+            <div class="example">
                 <og-button class="demo-button" label="Default"></og-button>
                 <og-button class="demo-button" label="Link" data-context="link"></og-button>
                 <og-button class="demo-button" label="Workflow" data-context="workflow"></og-button>
@@ -586,7 +586,7 @@
         og-list
         -->
         <og-card name="List">
-            <div slot="content">
+            <div>
                 <h3>Listitems with pre-selection</h3>
                 <og-list id="list1" selected="v2"></og-list>
 
@@ -623,7 +623,7 @@
         og-combobox
         -->
         <og-card name="Combobox">
-            <div slot="content" class="example example--column">
+            <div class="example example--column">
                 <div>
                     <h3>Preselected value</h3>
                     <og-combobox id="combobox1" value="3"></og-combobox><br>


### PR DESCRIPTION
# Pull Request

## Type of change

Please delete any option that is not relevant.

- [x] Other (a non-breaking change - please add details in the description section)

## Description

Improvement: og-card and og-dialog can be used without explicitely defining slot="content" for the inner element. I added an unnamed slot next to the content slot to avoid a breaking change here.

## Checklist

- [x] Local build is still running with my changes
- [ ] I added tests 
- [x] New and existing unit test pass locally with my changes
- [x] My changes do not contain any dead or commented out code
- [ ] I added documentation for public functionality
- [ ] I added comments, at least in hard-to-understand areas

