### PR TITLE
fix(calendar): resolve locales in npm artifact

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@orgenic/orgenic-ui",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -409,9 +409,9 @@
       }
     },
     "@stencil/core": {
-      "version": "1.0.2",
-      "resolved": "http://build:8081/repository/npm-public/@stencil/core/-/core-1.0.2.tgz",
-      "integrity": "sha512-5hug3gaFcAJSfyMTqppoOf9hJyrdYBVjlgnlW3IjDCTMKHFcnvXQh31E54n+Hv9z868/B0EbCxY5lhMVHbTIKw==",
+      "version": "1.0.3",
+      "resolved": "http://build:8081/repository/npm-public/@stencil/core/-/core-1.0.3.tgz",
+      "integrity": "sha512-JfaibY5o0ejQriIYhaWojTOBxt0y7ODL5H1aK7sgBC8GMXrE9hH83HhaSPSlE6QnedfmhfYC77czvxRnuj2xXg==",
       "dev": true,
       "requires": {
         "typescript": "3.5.1"
@@ -4577,19 +4577,19 @@
       "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "dev": true,
       "requires": {
-        "arr-diff": "^2.0.0",
-        "array-unique": "^0.2.1",
-        "braces": "^1.8.2",
-        "expand-brackets": "^0.1.4",
-        "extglob": "^0.3.1",
-        "filename-regex": "^2.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.1",
-        "kind-of": "^3.0.2",
-        "normalize-path": "^2.0.1",
-        "object.omit": "^2.0.0",
-        "parse-glob": "^3.0.4",
-        "regex-cache": "^0.4.2"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
       }
     },
     "mime": {
@@ -6628,6 +6628,15 @@
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "http://build:8081/repository/npm-public/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   ],
   "dependencies": {},
   "devDependencies": {
-    "@stencil/core": "^1.0.2",
+    "@stencil/core": "^1.0.3",
     "@stencil/sass": "^1.0.0",
     "@types/jest": "24.0.13",
     "@types/puppeteer": "1.12.4",

--- a/rollup-plugins/orgenic-ui-post-processing.js
+++ b/rollup-plugins/orgenic-ui-post-processing.js
@@ -40,7 +40,7 @@ function orgenicUiPostProcessing(config) {
                         await execute('node-sass src/styles/themes -o dist/themes');
                         momentLocales2Modules({ outDir: 'dist/orgenic-ui-assets/og-calendar-locales' });
                     } else {
-                        momentLocales2Modules({ outDir: 'www/build/orgenic-ui-assets/og-calendar-locales' });
+                        momentLocales2Modules({ outDir: 'www/orgenic-ui-assets/og-calendar-locales' });
                         await execute('node-sass src/styles/themes -o www/themes');
                     }
                 }, delay);

--- a/src/components/og-calendar/og-calendar.tsx
+++ b/src/components/og-calendar/og-calendar.tsx
@@ -36,7 +36,7 @@ export class OgCalendar {
     private internalMoment;
 
     async componentWillLoad() {
-        await loadMomentLocale(this.loc, moment, this.resourcesUrl);
+        await loadMomentLocale(this.loc, moment);
         this.internalMoment = moment();
     }
 

--- a/src/components/og-datepicker/og-datepicker.tsx
+++ b/src/components/og-datepicker/og-datepicker.tsx
@@ -116,7 +116,7 @@ export class OgDatepicker {
     flyoutCalendar: HTMLElement;
 
     async componentWillLoad() {
-        await loadMomentLocale(this.loc, moment, this.resourcesUrl);
+        await loadMomentLocale(this.loc, moment);
         this.setValue(this.value);
     }
 

--- a/src/components/og-internal-calendar/og-internal-calendar.tsx
+++ b/src/components/og-internal-calendar/og-internal-calendar.tsx
@@ -33,7 +33,7 @@ export class OgInternalCalendar {
     private internalMoment: Moment;
 
     async componentWillLoad() {
-        await loadMomentLocale(this.loc, moment, this.resourcesUrl);
+        await loadMomentLocale(this.loc, moment);
         this.internalMoment = moment();
     }
 

--- a/src/utils/moment-locale-loader.ts
+++ b/src/utils/moment-locale-loader.ts
@@ -4,12 +4,12 @@ export {
 };
 
 
-async function loadMomentLocale(locale: string, moment, resourceUrl: string) {
+async function loadMomentLocale(locale: string, moment) {
     if (moment.locales().indexOf(locale) >= 0) {
         return;
     }
 
-    const url = `${resourceUrl}orgenic-ui-assets/og-calendar-locales/${locale}.mjs`;
+    const url = `/orgenic-ui-assets/og-calendar-locales/${locale}.mjs`;
     try {
         const module = await import(/* webpackIgnore: true */ url);
         if (moment.locales().indexOf(locale) >= 0) {


### PR DESCRIPTION
# Pull Request

## Type of change

Please delete any option that is not relevant.

- [x] Bug fix (a non-breaking change which fixes an issue - please add the issue reference in the description section)

## Description

using the npm artifact, the calendar locales were resolved to /orgenic-ui/orgenic-ui-assets/og-calendar-locales/... the result was a 404 since the path starts with /orgenic-ui-assets/....
this is fixed with this PR

## Checklist

- [x] Local build is still running with my changes
- [x] New and existing unit test pass locally with my changes
- [x] My changes do not contain any dead or commented out code

