### PR TITLE
fix(datepicker): fix flyout position in small window

### DIFF
--- a/src/components/og-datepicker/og-datepicker.tsx
+++ b/src/components/og-datepicker/og-datepicker.tsx
@@ -174,7 +174,7 @@ export class OgDatepicker {
         }
 
         return {
-            top: flyoutTop + 'px',
+            top: Math.max(0, flyoutTop) + 'px',
         }
     }
 


### PR DESCRIPTION
# Pull Request

## Type of change

Please delete any option that is not relevant.

- [x] Bug fix (a non-breaking change which fixes an issue - please add the issue reference in the description section)

## Description

If window height is so small that the datepicker flyout does not fit above or below datepicker, it will be placed at top pixel 0 to be fully visible.

## Checklist

- [x] Local build is still running with my changes
- [x] New and existing unit test pass locally with my changes
- [x] My changes do not contain any dead or commented out code

