### PR TITLE
fix: move moment to runtime dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@orgenic/orgenic-ui",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,9 @@
   "pre-commit": [
     "check-licenseheader"
   ],
-  "dependencies": {},
+  "dependencies": {
+    "moment": "^2.24.0"
+  },
   "devDependencies": {
     "@stencil/core": "^1.0.3",
     "@stencil/sass": "^1.0.0",
@@ -55,7 +57,6 @@
     "glob": "^7.1.4",
     "jest": "24.8.0",
     "jest-cli": "24.8.0",
-    "moment": "^2.24.0",
     "node-sass": "^4.12.0",
     "pre-commit": "^1.2.2",
     "puppeteer": "1.17.0",


### PR DESCRIPTION
resolves error when building app that uses orgenic-ui

# Pull Request

## Type of change

Please delete any option that is not relevant.

- [ ] Bug fix (a non-breaking change which fixes an issue - please add the issue reference in the description section)

## Description
move moment to runtime dependencies

Fixes # (issue)
#72 

## Checklist

- [ ] Local build is still running with my changes
- [ ] I added tests 
- [ ] New and existing unit test pass locally with my changes
- [ ] My changes do not contain any dead or commented out code
- [ ] I added documentation for public functionality
- [ ] I added comments, at least in hard-to-understand areas

