### PR TITLE
fix(og-card) hide footer and header when there's no content

### DIFF
--- a/src/components/og-card/og-card.tsx
+++ b/src/components/og-card/og-card.tsx
@@ -4,7 +4,7 @@
  * See LICENSE file at https://github.com/orgenic/orgenic-ui/blob/master/LICENSE
  **/
 
-import { h, Component, Prop } from '@stencil/core';
+import { h, Element, Component, Prop } from '@stencil/core';
 
 @Component({
   tag: 'og-card',
@@ -12,50 +12,48 @@ import { h, Component, Prop } from '@stencil/core';
   shadow: true
 })
 export class OgCard {
+
+  @Element()
+  public hostElement: HTMLElement;
+
   /**
    * The title for this card (optional)
    */
   @Prop()
   public name: string;
 
-  public handleDivRef(el: HTMLElement) {
-    if (!el) {
-      return;
-    }
-
-    const slot = el.firstChild as HTMLSlotElement;
-    if (!slot) {
-      return;
-    }
-
-    el.style.display = slot.assignedNodes().length > 0 ? 'block' : 'none';
-
-    slot.addEventListener('slotchange', () => {
-      el.style.display = slot.assignedNodes().length > 0 ? 'block' : 'none';
-    })
+  /**
+   * Check if a given name exists as a slot inside this component.
+   */
+  private hasSlot(name: string): boolean {
+    const slot = this.hostElement.querySelector(`[slot="${name}"]`);
+    return slot ? true : false;
   }
 
   public render(): HTMLElement {
     return (
       <div class="og-card">
-        <div class="og-card__header">
+        {
+          (this.hasSlot('header') || this.name) && <div class="og-card__header">
           {
             this.name
               ? <span class="og-card__title">{ this.name }</span>
               : ""
           }
           <slot name="header"></slot>
-        </div>
-
+          </div>
+        }
         <div class="og-card__content">
           {/* allow the user to use an unnamed slot instead of always having to assign as "content" */}
           <slot></slot>
           <slot name="content"></slot>
         </div>
 
-        <div class="og-card__footer" ref={ el => this.handleDivRef(el) }>
-          <slot name="footer"></slot>
-        </div>
+        {
+          this.hasSlot('footer') && <div class="og-card__footer">
+            <slot name="footer"></slot>
+          </div>
+        }
       </div>
     );
   }

--- a/src/components/og-card/og-card.tsx
+++ b/src/components/og-card/og-card.tsx
@@ -27,7 +27,7 @@ export class OgCard {
    */
   private hasSlot(name: string): boolean {
     const slot = this.hostElement.querySelector(`[slot="${name}"]`);
-    return slot ? true : false;
+    return slot !== null;
   }
 
   public render(): HTMLElement {

--- a/src/components/og-list/readme.md
+++ b/src/components/og-list/readme.md
@@ -7,19 +7,16 @@
 
 ## Properties
 
-| Property           | Attribute            | Description                                                                                                 | Type                 | Default                |
-| ------------------ | -------------------- | ----------------------------------------------------------------------------------------------------------- | -------------------- | ---------------------- |
-| `disabled`         | `disabled`           | Determines, whether the control is disabled or not                                                          | `boolean`            | `undefined`            |
-| `disabledProperty` | `disabled-property`  | Set the property for the items to define as disabled. Default: 'disabled'                                   | `string`             | `'disabled'`           |
-| `emptyListMessage` | `empty-list-message` | Set the text that will be displayed if the items array is empty.                                            | `string`             | `'No items available'` |
-| `imageUrlProperty` | `image-url-property` | Set the property for the items to define as image url. *Optional* Default: no image                         | `string`             | `undefined`            |
-| `items`            | --                   | An array of items to choose from                                                                            | `any[]`              | `undefined`            |
-| `keyProperty`      | `key-property`       | Set the property for the items to define as value. Default: 'key'                                           | `string`             | `'key'`                |
-| `labelProperty`    | `label-property`     | Set the property for the items to define as label. Default: 'label'                                         | `string`             | `'label'`              |
-| `multiselect`      | `multiselect`        | Enables selection of multiple items                                                                         | `boolean`            | `undefined`            |
-| `required`         | `required`           | Requires a selection of at least one item. If one item is selected it prevents the user from deselecting it | `boolean`            | `undefined`            |
-| `selected`         | `selected`           | The key of the selected list item                                                                           | `string \| string[]` | `undefined`            |
-| `valueProperty`    | `value-property`     | Set the property for the items to define as value. *Optional* Default: no value                             | `string`             | `undefined`            |
+| Property           | Attribute            | Description                                                                                                 | Type                 | Default                                                |
+| ------------------ | -------------------- | ----------------------------------------------------------------------------------------------------------- | -------------------- | ------------------------------------------------------ |
+| `disabled`         | `disabled`           | Determines, whether the control is disabled or not                                                          | `boolean`            | `undefined`                                            |
+| `emptyListMessage` | `empty-list-message` | Set the text that will be displayed if the items array is empty.                                            | `string`             | `'No items available'`                                 |
+| `items`            | --                   | An array of items to choose from                                                                            | `any[]`              | `undefined`                                            |
+| `multiselect`      | `multiselect`        | Enables selection of multiple items                                                                         | `boolean`            | `undefined`                                            |
+| `required`         | `required`           | Requires a selection of at least one item. If one item is selected it prevents the user from deselecting it | `boolean`            | `undefined`                                            |
+| `selected`         | `selected`           | Key(s) of the selected list item(s)                                                                         | `string \| string[]` | `undefined`                                            |
+| `template`         | `template`           |                                                                                                             | `string`             | `'default'`                                            |
+| `templateOptions`  | `template-options`   |                                                                                                             | `any`                | `{ key: 'key', label: 'label', disabled: 'disabled' }` |
 
 
 ## Events
@@ -31,22 +28,22 @@
 
 ## CSS Custom Properties
 
-| Name                          | Description                                |
-| ----------------------------- | ------------------------------------------ |
-| `--og-list-Opacity`           | Overall opacity of the list                |
-| `--og-list-Opacity--disabled` | Overall opacity of the list when disabled. |
+| Name                          | Description                               |
+| ----------------------------- | ----------------------------------------- |
+| `--og-list-Opacity`           | Overall opacity of the list               |
+| `--og-list-Opacity--disabled` | Overall opacity of the list when disabled |
 
 
 ## Dependencies
 
 ### Depends on
 
-- [og-list-item](..\og-list-item)
+- [og-list-template-default](..\og-list-template-default)
 
 ### Graph
 ```mermaid
 graph TD;
-  og-list --> og-list-item
+  og-list --> og-list-template-default
   style og-list fill:#f9f,stroke:#333,stroke-width:4px
 ```
 


### PR DESCRIPTION
# Pull Request

## Type of change

Please delete any option that is not relevant.

- [ ] New feature (a non-breaking change)
- [ ] Breaking change
- [x] Bug fix (a non-breaking change which fixes an issue - please add the issue reference in the description section)
- [ ] Other (a non-breaking change - please add details in the description section)

## Description

Fixes issue where header (incl. spacing) was still visible, even without content or title. 

Fixes #40 #99 

## Checklist

- [x] Local build is still running with my changes
- [ ] I added tests 
- [ ] New and existing unit test pass locally with my changes
- [x] My changes do not contain any dead or commented out code
- [ ] I added documentation for public functionality
- [ ] I added comments, at least in hard-to-understand areas

