### PR TITLE
fix(og-layout-child): handle overflow respecting max-size

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -208,7 +208,7 @@ export namespace Components {
     */
     'minSize': string;
     /**
-    * The weight defines the resize behavior. A component with weight 2 will be twice as large as a component with weight 1.. Default: "1"
+    * The weight defines the resize behavior. A component with weight 2 will be twice as large as a component with weight 1. Default: "1"
     */
     'weight': number;
   }
@@ -846,7 +846,7 @@ declare namespace LocalJSX {
     */
     'minSize'?: string;
     /**
-    * The weight defines the resize behavior. A component with weight 2 will be twice as large as a component with weight 1.. Default: "1"
+    * The weight defines the resize behavior. A component with weight 2 will be twice as large as a component with weight 1. Default: "1"
     */
     'weight'?: number;
   }

--- a/src/components/og-layout-child/og-layout-child.scss
+++ b/src/components/og-layout-child/og-layout-child.scss
@@ -11,10 +11,11 @@
  */
 
 :host {
+    box-sizing: border-box;
     display: block;
     flex-grow: var(--og-layout-child--grow, 1);
     flex-shrink: var(--og-layout-child--shrink, 1);
-    flex-basis: var(--og-layout-child--basis, 0);
+    flex-basis: var(--og-layout-child--basis, 0%);
     order: var(--og-layout-child--order, 0);
     align-self: var(--og-layout-child--align, auto);
 
@@ -22,8 +23,14 @@
     max-width: var(--og-layout-child--max-width);
     min-height: var(--og-layout-child--min-height);
     max-height: var(--og-layout-child--max-height);
+
+    *,
+    *:before,
+    *:after {
+        box-sizing: inherit;
+    }
 }
 
-:host[max-size] {
+:host([max-size]) {
     overflow: auto;
 }

--- a/src/components/og-layout-child/og-layout-child.scss
+++ b/src/components/og-layout-child/og-layout-child.scss
@@ -24,3 +24,6 @@
     max-height: var(--og-layout-child--max-height);
 }
 
+:host[max-size] {
+    overflow: auto;
+}

--- a/src/components/og-layout-child/og-layout-child.tsx
+++ b/src/components/og-layout-child/og-layout-child.tsx
@@ -13,7 +13,7 @@ import { h, Component, Element, Prop } from '@stencil/core';
 })
 export class OgLayoutChild {
   /**
-   * The weight defines the resize behavior. A component with weight 2 will be twice as large as a component with weight 1.. Default: "1"
+   * The weight defines the resize behavior. A component with weight 2 will be twice as large as a component with weight 1. Default: "1"
    */
   @Prop()
   public weight: number = 1;
@@ -39,17 +39,14 @@ export class OgLayoutChild {
 
   public applyValues() {
     const grow = this.weight.toString();
-    const shrink = this.minSize !== 'initial' ? '0' : 'initial';
-    const basis = '0';
-    const order = '0';
-    const align = 'auto';
+    const shrink = this.minSize !== 'initial' ? '0' : '1';
+    const parentElement = this.element.parentElement;
+    const parentOrientationIsVertical = parentElement && parentElement.nodeName.toLowerCase() === 'og-layout-container' && parentElement.getAttribute('orientation') === 'vertical';
+
     this.element.style.setProperty('--og-layout-child--grow', grow);
     this.element.style.setProperty('--og-layout-child--shrink', shrink);
-    this.element.style.setProperty('--og-layout-child--basis', basis);
-    this.element.style.setProperty('--og-layout-child--order', order);
-    this.element.style.setProperty('--og-layout-child--align', align);
 
-    if (this.element.parentElement.getAttribute('orientation') === 'vertical') {
+    if (parentOrientationIsVertical) {
       // height
       this.element.style.setProperty('--og-layout-child--min-width', 'initial');
       this.element.style.setProperty('--og-layout-child--max-width', 'initial');

--- a/src/components/og-layout-child/readme.md
+++ b/src/components/og-layout-child/readme.md
@@ -5,11 +5,11 @@
 
 ## Properties
 
-| Property  | Attribute  | Description                                                                                                                          | Type     | Default     |
-| --------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------ | -------- | ----------- |
-| `maxSize` | `max-size` | The maximum size of the layout child. Can be pixel (e.g. 250px) or percent (e.g. 50%).                                               | `string` | `'initial'` |
-| `minSize` | `min-size` | The minimum size of the layout child. Can be pixel (e.g. 150px) or percent (e.g. 30%).                                               | `string` | `'initial'` |
-| `weight`  | `weight`   | The weight defines the resize behavior. A component with weight 2 will be twice as large as a component with weight 1.. Default: "1" | `number` | `1`         |
+| Property  | Attribute  | Description                                                                                                                         | Type     | Default     |
+| --------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------- | -------- | ----------- |
+| `maxSize` | `max-size` | The maximum size of the layout child. Can be pixel (e.g. 250px) or percent (e.g. 50%).                                              | `string` | `'initial'` |
+| `minSize` | `min-size` | The minimum size of the layout child. Can be pixel (e.g. 150px) or percent (e.g. 30%).                                              | `string` | `'initial'` |
+| `weight`  | `weight`   | The weight defines the resize behavior. A component with weight 2 will be twice as large as a component with weight 1. Default: "1" | `number` | `1`         |
 
 
 ## CSS Custom Properties

--- a/src/components/og-layout-container/og-layout-container.scss
+++ b/src/components/og-layout-container/og-layout-container.scss
@@ -12,12 +12,19 @@
  */
 
 :host {
+    box-sizing: border-box;
     display: flex;
     flex-direction: var(--og-layout-container--direction, row);
     justify-content: var(--og-layout-container--justify, space-between);
     align-items: var(--og-layout-container--align, stretch);
     flex-wrap: var(--og-layout-container--wrap, nowrap);
     overflow: var(--og-layout-container--overflow, visible);
+
+    *,
+    *:before,
+    *:after {
+        box-sizing: inherit;
+    }
 }
 
 ::slotted(*:not(og-layout-child)) {

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -1,2 +1,0 @@
-@import 'themesets/_index.scss';
-@import 'themesets/_index.scss';


### PR DESCRIPTION
# Pull Request

## Type of change

- [ ] New feature (a non-breaking change)
- [ ] Breaking change
- [x] Bug fix (a non-breaking change which fixes an issue - please add the issue reference in the description section)
- [ ] Other (a non-breaking change - please add details in the description section)

## Description

Fixes the issue that og-layout-child elements could be exceeded by their content when a max-size (that is, max-width or max-height, depending on the orientation of the parent element) was set.

## Checklist

- [x] Local build is still running with my changes
- [ ] I added tests 
- [x] New and existing unit test pass locally with my changes
- [x] My changes do not contain any dead or commented out code
- [ ] I added documentation for public functionality
- [ ] I added comments, at least in hard-to-understand areas

