### PR TITLE
fix: og-internal-calender skipping first week on "en" locale

### DIFF
--- a/src/components/og-internal-calendar/og-internal-calendar.e2e.ts
+++ b/src/components/og-internal-calendar/og-internal-calendar.e2e.ts
@@ -1,0 +1,35 @@
+import { newE2EPage, E2EElement, E2EPage } from '@stencil/core/testing';
+
+describe('og-internal-calendar', () => {
+  let page: E2EPage;
+  let component: E2EElement;
+
+  beforeEach(async () => {
+    page = await newE2EPage();
+    await page.setContent(`
+            <og-internal-calendar year="2020" month="1" showCalendarWeek>
+            </og-internal-calendar>`);
+
+    component = await page.find('og-internal-calendar');
+  });
+
+  it('renders', async () => {
+    expect(component).toHaveClass('hydrated');
+  });
+
+  it('starts with the right week', async () => {
+    const calendarWeek: E2EElement = await page.find(
+      'og-internal-calendar >>> .week'
+    );
+    expect(calendarWeek).toBeDefined();
+    expect(calendarWeek).toEqualText('5');
+  });
+
+  it('starts with the right day', async () => {
+    const calendarWeek: E2EElement = await page.find(
+      'og-internal-calendar >>> .day'
+    );
+    expect(calendarWeek).toBeDefined();
+    expect(calendarWeek).toEqualText('26');
+  });
+});

--- a/src/components/og-internal-calendar/og-internal-calendar.tsx
+++ b/src/components/og-internal-calendar/og-internal-calendar.tsx
@@ -39,19 +39,25 @@ export class OgInternalCalendar {
   public dateClicked: EventEmitter; // emits moment object
 
   private internalMoment: Moment;
+  private firstDayOfWeek: number = 0;
+  private weekDayArray: number[] = [0, 1, 2, 3, 4, 5, 6];
 
   public async componentWillLoad() {
     await loadMomentLocale(this.loc, moment);
     this.internalMoment = moment();
   }
 
-  public getFirstDayOfWeek() {
-    return this.internalMoment.startOf('week').day();
+  /**
+   * Sets the date of the `internalMoment` object to the first weekday
+   * and stores the information about the start of the week as `firstDayOfWeek`
+   */
+  public setFirstDayOfWeek() {
+    this.firstDayOfWeek = this.internalMoment.startOf('week').day();
   }
 
-  public getDayArray() {
-    return [0,1,2,3,4,5,6].map(d => {
-      return (d + this.getFirstDayOfWeek()) % 7;
+  public calculateDayArray() {
+    this.weekDayArray = [0, 1, 2, 3, 4, 5, 6].map(d => {
+      return (d + this.firstDayOfWeek) % 7;
     });
   }
 
@@ -85,13 +91,8 @@ export class OgInternalCalendar {
     this.internalMoment.month(this.month);
     this.internalMoment.date(1);
 
-    const firstDayOfWeek = this.getFirstDayOfWeek();
-
-    if (this.internalMoment.day() < firstDayOfWeek) {
-      this.internalMoment.day(firstDayOfWeek - 7);
-    } else {
-      this.internalMoment.day(firstDayOfWeek);
-    }
+    this.setFirstDayOfWeek();
+    this.calculateDayArray();
   }
 
   public render(): HTMLElement[] {
@@ -101,27 +102,28 @@ export class OgInternalCalendar {
       <table>
         <thead>
           <tr>
-            { this.showCalendarWeek && <th></th> }
+            {this.showCalendarWeek && <th></th>}
             {
-              this.getDayArray().map((d): HTMLElement => {
-                return <th>{ this.internalMoment.day(d).format('dd') }</th>;
+              this.weekDayArray.map((d): HTMLElement => {
+                const localM = this.internalMoment.clone();
+                return <th>{localM.day(d).format('dd')}</th>;
               })
             }
           </tr>
         </thead>
         <tbody>
           {
-            [0,1,2,3,4,5].map((): HTMLElement => {
+            [0, 1, 2, 3, 4, 5].map((): HTMLElement => {
               return (<tr>
-                { this.showCalendarWeek && <td class="week">{ this.internalMoment.week() }</td> }
+                {this.showCalendarWeek && <td class="week">{this.internalMoment.week()}</td>}
                 {
-                  [0,1,2,3,4,5,6].map((): HTMLElement => {
+                  this.weekDayArray.map((): HTMLElement => {
                     const localM = this.internalMoment.clone();
                     this.internalMoment.add(1, 'd');
                     return <td
-                      class={ this.getClasses(localM) }
-                      onClick={ () => this.dateClicked.emit(localM) }>
-                      { localM.date() }
+                      class={this.getClasses(localM)}
+                      onClick={() => this.dateClicked.emit(localM)}>
+                      {localM.date()}
                     </td>;
                   })
                 }

--- a/src/components/og-internal-calendar/og-internal-calendar.tsx
+++ b/src/components/og-internal-calendar/og-internal-calendar.tsx
@@ -55,7 +55,7 @@ export class OgInternalCalendar {
     this.firstDayOfWeek = this.internalMoment.startOf('week').day();
   }
 
-  public calculateDayArray() {
+  private calculateDayArray() {
     this.weekDayArray = [0, 1, 2, 3, 4, 5, 6].map(d => {
       return (d + this.firstDayOfWeek) % 7;
     });


### PR DESCRIPTION
Signed-off-by: Tobias Dobbrunz <tobias.dobbrunz@maximago.de>

# Pull Request

## Type of change

Please delete any option that is not relevant.

- [ ] New feature (a non-breaking change)
- [ ] Breaking change
- [X] Bug fix (a non-breaking change which fixes an issue - please add the issue reference in the description section)
- [ ] Other (a non-breaking change - please add details in the description section)

## Description

Fixes issue where calendar cuts off first week on "en" locations

Fixes # (issue)

## Checklist

- [X] Local build is still running with my changes
- [X] I added tests 
- [X] New and existing unit test pass locally with my changes
- [X] My changes do not contain any dead or commented out code
- [ ] I added documentation for public functionality
- [X] I added comments, at least in hard-to-understand areas

